### PR TITLE
Add layer-based metaverse controls

### DIFF
--- a/docs/data.js
+++ b/docs/data.js
@@ -1,12 +1,13 @@
 export const nodes = [
-  { id: "merlot", category: "wine" },
-  { id: "cabernet", category: "wine" },
-  { id: "pinotnoir", category: "wine" },
-  { id: "chardonnay", category: "wine" },
-  { id: "pepperoni", category: "pizza" },
-  { id: "margherita", category: "pizza" },
-  { id: "bbqchicken", category: "pizza" },
-  { id: "mushroom", category: "pizza" }
+  { id: "merlot",      category: "wine",  layer: 0 },
+  { id: "cabernet",    category: "wine",  layer: 0 },
+  { id: "pinotnoir",   category: "wine",  layer: 0 },
+  { id: "chardonnay",  category: "wine",  layer: 0 },
+
+  { id: "pepperoni",   category: "pizza", layer: 5 },
+  { id: "margherita",  category: "pizza", layer: 5 },
+  { id: "bbqchicken",  category: "pizza", layer: 5 },
+  { id: "mushroom",    category: "pizza", layer: 5 }
 ];
 
 export const links = [

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,13 @@
   </style>
 </head>
 <body>
+  <input id="layerSlider" type="range" min="0" max="5" step="1" value="0"
+         style="position:fixed;top:10%;right:12px;height:80%;
+                writing-mode:bt-lr;transform:rotate(180deg);
+                accent-color:#ff008c;" />
+  <div id="layerLabel"
+       style="position:fixed;right:16px;top:8px;
+              color:#fff;font:12px sans-serif;">Varietal</div>
   <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/docs/layers.js
+++ b/docs/layers.js
@@ -1,0 +1,15 @@
+import * as THREE from "https://unpkg.com/three@0.153.0/build/three.module.js?module";
+export const layerNames = [
+  "Varietal",
+  "Wine Type",
+  "Region",
+  "State / AVA",
+  "Pizza Style",
+  "Topping"
+];
+
+export function colorFor(layer) {
+  // 80 s neon gradient (magenta → green).
+  const hue = 300 - layer * 30;          // 300°, 270°, 240° … 150°
+  return new THREE.Color(`hsl(${hue},100%,60%)`);
+}

--- a/wine_pizza_cosmos/app.js
+++ b/wine_pizza_cosmos/app.js
@@ -1,6 +1,7 @@
 import * as THREE from "https://unpkg.com/three@0.153.0/build/three.module.js?module";
 import { OrbitControls } from "https://unpkg.com/three@0.153.0/examples/jsm/controls/OrbitControls.js?module";
 import { nodes as rawNodes, links as rawLinks } from "./data.js";
+import { layerNames, colorFor } from "./layers.js";
 
 const scene = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(60, window.innerWidth/window.innerHeight, 0.1, 1000);
@@ -10,6 +11,16 @@ const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.setPixelRatio(window.devicePixelRatio || 1);
 document.body.appendChild(renderer.domElement);
+
+const slider = document.getElementById("layerSlider");
+const label  = document.getElementById("layerLabel");
+let activeLayer = parseInt(slider.value, 10);
+label.textContent = layerNames[activeLayer];
+slider.oninput = e => {
+  activeLayer = parseInt(e.target.value, 10);
+  label.textContent = layerNames[activeLayer];
+  updateLayerVisibility();
+};
 
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
@@ -66,8 +77,9 @@ const spriteMat=new THREE.SpriteMaterial({map:glowTex,blending:THREE.AdditiveBle
 
 const threshold=2;
 nodes.forEach(n=>{
-  const mat=n.category==='wine'?matWine:matPizza;
-  const mesh=new THREE.Mesh(sphereGeo,mat);
+  const material = (n.category==='wine'?matWine:matPizza).clone();
+  material.color.copy(colorFor(n.layer));
+  const mesh=new THREE.Mesh(sphereGeo,material);
   mesh.position.set(n.x,n.y,n.z); mesh.userData.id=n.id;
   nodeGroup.add(mesh);
   if(neighbors[n.id].length>=threshold){
@@ -79,6 +91,20 @@ nodes.forEach(n=>{
     mesh.add(glow);
   }
 });
+
+function updateLayerVisibility() {
+  nodeGroup.children.forEach(mesh => {
+    const L = nodes[nodeIndex[mesh.userData.id]].layer;
+    mesh.visible = (L === activeLayer);
+  });
+  lineGroup.children.forEach((line, i) => {
+    const { source, target } = links[i];
+    const LA = nodes[source].layer;
+    const LB = nodes[target].layer;
+    line.visible = (LA === activeLayer || LB === activeLayer);
+  });
+}
+updateLayerVisibility();
 
 const lineMat=new THREE.LineBasicMaterial({color:0x8844ff,transparent:true,opacity:0.8});
 links.forEach(l=>{
@@ -125,9 +151,19 @@ function physics(){
   nodes.forEach(n=>{n.fx=n.fy=n.fz=0;});
   links.forEach(l=>{
     const A=nodes[l.source],B=nodes[l.target];
+    const boostA = counts[nodes[l.source].id] || 0;
+    const boostB = counts[nodes[l.target].id] || 0;
+    l.strength += 0.0003 * (boostA + boostB);
     let dx=B.x-A.x,dy=B.y-A.y,dz=B.z-A.z;const dist=Math.hypot(dx,dy,dz)||0.001;
     const f=linkK*l.strength*(dist-linkLen); dx/=dist;dy/=dist;dz/=dist;
     A.fx+=dx*f;A.fy+=dy*f;A.fz+=dz*f; B.fx-=dx*f;B.fy-=dy*f;B.fz-=dz*f;
+    [l.source, l.target].forEach(idx => {
+      const n = nodes[idx];
+      if (n.glowSprite) {
+        const alpha = Math.min(l.strength, 2) * 0.5;
+        n.glowSprite.material.opacity = alpha;
+      }
+    });
   });
   for(let i=0;i<nodes.length;i++)for(let j=i+1;j<nodes.length;j++){
     const A=nodes[i], B=nodes[j];

--- a/wine_pizza_cosmos/data.js
+++ b/wine_pizza_cosmos/data.js
@@ -1,12 +1,13 @@
 export const nodes = [
-  { id: "merlot", category: "wine" },
-  { id: "cabernet", category: "wine" },
-  { id: "pinotnoir", category: "wine" },
-  { id: "chardonnay", category: "wine" },
-  { id: "pepperoni", category: "pizza" },
-  { id: "margherita", category: "pizza" },
-  { id: "bbqchicken", category: "pizza" },
-  { id: "mushroom", category: "pizza" }
+  { id: "merlot",      category: "wine",  layer: 0 },
+  { id: "cabernet",    category: "wine",  layer: 0 },
+  { id: "pinotnoir",   category: "wine",  layer: 0 },
+  { id: "chardonnay",  category: "wine",  layer: 0 },
+
+  { id: "pepperoni",   category: "pizza", layer: 5 },
+  { id: "margherita",  category: "pizza", layer: 5 },
+  { id: "bbqchicken",  category: "pizza", layer: 5 },
+  { id: "mushroom",    category: "pizza", layer: 5 }
 ];
 
 export const links = [

--- a/wine_pizza_cosmos/index.html
+++ b/wine_pizza_cosmos/index.html
@@ -14,6 +14,13 @@
   </style>
 </head>
 <body>
+  <input id="layerSlider" type="range" min="0" max="5" step="1" value="0"
+         style="position:fixed;top:10%;right:12px;height:80%;
+                writing-mode:bt-lr;transform:rotate(180deg);
+                accent-color:#ff008c;" />
+  <div id="layerLabel"
+       style="position:fixed;right:16px;top:8px;
+              color:#fff;font:12px sans-serif;">Varietal</div>
   <script type="module" src="./app.js"></script>
 </body>
 </html>

--- a/wine_pizza_cosmos/layers.js
+++ b/wine_pizza_cosmos/layers.js
@@ -1,0 +1,15 @@
+import * as THREE from "https://unpkg.com/three@0.153.0/build/three.module.js?module";
+export const layerNames = [
+  "Varietal",
+  "Wine Type",
+  "Region",
+  "State / AVA",
+  "Pizza Style",
+  "Topping"
+];
+
+export function colorFor(layer) {
+  // 80 s neon gradient (magenta → green).
+  const hue = 300 - layer * 30;          // 300°, 270°, 240° … 150°
+  return new THREE.Color(`hsl(${hue},100%,60%)`);
+}


### PR DESCRIPTION
## Summary
- color-coded layers for metaverse nodes
- slider UI to switch layers
- adaptive glow effect and link strengthening
- update docs to match interactive features

## Testing
- `node --check wine_pizza_cosmos/app.js`
- `node --check wine_pizza_cosmos/data.js`
- `node --check wine_pizza_cosmos/layers.js`
- `node --check docs/app.js`
- `node --check docs/data.js`
- `node --check docs/layers.js`
