### PR TITLE
Add ESLint config and npm setup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+*.json
+dist/**

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,6 +1,6 @@
 import * as THREE from "https://unpkg.com/three@0.153.0/build/three.module.js?module";
 import { OrbitControls } from "https://unpkg.com/three@0.153.0/examples/jsm/controls/OrbitControls.js?module";
-import { CSS2DRenderer, CSS2DObject } from "https://unpkg.com/three@0.153.0/examples/jsm/renderers/CSS2DRenderer.js";
+import { CSS2DRenderer, CSS2DObject } from "https://unpkg.com/three@0.153.0/examples/jsm/renderers/CSS2DRenderer.js?module";
 import { layerNames, colorFor } from "./layers.js";
 
 const scene = new THREE.Scene();

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,19 +1,20 @@
+import eslintPluginImport from 'eslint-plugin-import';
+
 export default [
   {
-    files: ["**/*.js"],
+    ignores: ['node_modules/**', '*.json', 'dist/**'],
+    files: ['**/*.js'],
     languageOptions: {
       ecmaVersion: 2022,
-      sourceType: "module",
-      globals: {
-        window: true,
-        document: true
-      }
+      sourceType: 'module',
+      globals: { window: true, document: true }
     },
+    plugins: { import: eslintPluginImport },
     rules: {
-      // Example: You can add rules here (see eslint.org/docs)
-      semi: "error",
-      "no-unused-vars": "warn",
-      "no-console": "off"
+      semi: 'error',
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-duplicate-imports': 'error',
+      'import/no-unresolved': 'off' // CDN imports
     }
   }
 ];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pizzaverse",
+  "version": "1.0.0",
+  "description": "",
+  "main": "eslint.config.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint": "eslint \"{docs,wine_pizza_cosmos}/**/*.js\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "eslint-plugin-import": "^2.29.1"
+  }
+}

--- a/wine_pizza_cosmos/app.js
+++ b/wine_pizza_cosmos/app.js
@@ -1,6 +1,6 @@
 import * as THREE from "https://unpkg.com/three@0.153.0/build/three.module.js?module";
 import { OrbitControls } from "https://unpkg.com/three@0.153.0/examples/jsm/controls/OrbitControls.js?module";
-import { CSS2DRenderer, CSS2DObject } from "https://unpkg.com/three@0.153.0/examples/jsm/renderers/CSS2DRenderer.js";
+import { CSS2DRenderer, CSS2DObject } from "https://unpkg.com/three@0.153.0/examples/jsm/renderers/CSS2DRenderer.js?module";
 import { layerNames, colorFor } from "./layers.js";
 
 const scene = new THREE.Scene();


### PR DESCRIPTION
## Summary
- set up npm with eslint and eslint-plugin-import
- configure eslint flat config with import plugin
- add `.eslintignore`
- update CDN imports to use `?module`

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-import')*