### PR TITLE
Update label visibility

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -213,9 +213,8 @@ function highlightLines(){
     }
     const a=nodes[links[i].source].id;
     const b=nodes[links[i].target].id;
-    const strong=(a===selectedId && (strongMap[selectedId]||[]).includes(b)) ||
-                 (b===selectedId && (strongMap[selectedId]||[]).includes(a));
-    if(strong){
+    const connected=(a===selectedId || b===selectedId);
+    if(connected){
       ln.material.color.set(0xffff00);
       ln.material.opacity=1;
     }else{
@@ -410,9 +409,11 @@ function updateLabelVisibility(){
 
   nodes.forEach(n => {
     const el = n.labelObj.element;
-    const show = (selectedId && (selectedId===n.id || (strongMap[selectedId]||[]).includes(n.id))) ||
-                 (currentHover && currentHover.userData.id===n.id) ||
-                 n.isImportant;
+    const isSelected = selectedId && selectedId === n.id;
+    const isNeighbor = selectedId && (neighbors[selectedId] || []).includes(n.id);
+    const isHover = currentHover && currentHover.userData.id === n.id;
+    const isActiveImportant = n.layer === activeLayer && n.isImportant;
+    const show = isSelected || isNeighbor || isHover || isActiveImportant;
     el.style.opacity = show ? t : 0;
 
   });

--- a/wine_pizza_cosmos/app.js
+++ b/wine_pizza_cosmos/app.js
@@ -214,9 +214,8 @@ function highlightLines(){
     }
     const a=nodes[links[i].source].id;
     const b=nodes[links[i].target].id;
-    const strong=(a===selectedId && (strongMap[selectedId]||[]).includes(b)) ||
-                 (b===selectedId && (strongMap[selectedId]||[]).includes(a));
-    if(strong){
+    const connected=(a===selectedId || b===selectedId);
+    if(connected){
       ln.material.color.set(0xffff00);
       ln.material.opacity=1;
     }else{
@@ -239,7 +238,7 @@ function refreshLabels() {
   if (!selectedId) return;
 
   visibleSet.add(selectedId);
-  const neighbours = strongMap[selectedId] || [];
+  const neighbours = neighbors[selectedId] || [];
   neighbours.forEach(id => visibleSet.add(id));
 
   nodeGroup.children.forEach(n => {
@@ -438,9 +437,10 @@ function updateLabelVisibility(){
     const el = n.labelObj.element;
 
     const isSelectedOrNeighbor = visibleSet.has(n.id);
-    const isHovered = !draggingNode && !selectedId && currentHover && currentHover.userData.id === n.id;
+    const isHovered = !draggingNode && currentHover && currentHover.userData.id === n.id;
+    const isActiveImportant = n.layer === activeLayer && n.isImportant;
 
-    el.style.opacity = (isSelectedOrNeighbor || isHovered) ? zoomFactor : 0;
+    el.style.opacity = (isSelectedOrNeighbor || isHovered || isActiveImportant) ? zoomFactor : 0;
   });
 
   highlightLines();


### PR DESCRIPTION
## Summary
- highlight all neighbor lines when a node is selected
- show labels only for the active layer unless node is selected, hovered or a neighbor

## Testing
- `npm run lint`