### PR TITLE
Fix relative asset paths for GitHub Pages

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -446,10 +446,10 @@ function animate(){
 }
 
 Promise.all([
-  fetch('nodes.json').then(r=>r.json()),
-  fetch('links.json').then(r=>r.json()),
-  fetch('bottle_nodes.json').then(r=>r.json()),
-  fetch('bottle_links.json').then(r=>r.json())
+  fetch('./nodes.json').then(r=>r.json()),
+  fetch('./links.json').then(r=>r.json()),
+  fetch('./bottle_nodes.json').then(r=>r.json()),
+  fetch('./bottle_links.json').then(r=>r.json())
 ])
   .then(([baseNodes, baseLinks, bottleNodes, bottleLinks]) => {
     const labelToId = {};

--- a/docs/bottleGraph.js
+++ b/docs/bottleGraph.js
@@ -10,8 +10,8 @@ const svg = d3.select("body")
   .style("background", "#111");
 
 Promise.all([
-  fetch('bottle_nodes.json').then(r => r.json()),
-  fetch('bottle_links.json').then(r => r.json())
+  fetch('./bottle_nodes.json').then(r => r.json()),
+  fetch('./bottle_links.json').then(r => r.json())
 ]).then(([nodes, links]) => {
   init(nodes, links);
 });

--- a/docs/bottle_index.html
+++ b/docs/bottle_index.html
@@ -9,6 +9,6 @@
   </style>
 </head>
 <body>
-<script type="module" src="bottleGraph.js"></script>
+<script type="module" src="./bottleGraph.js"></script>
 </body>
 </html>

--- a/wine_pizza_cosmos/app.js
+++ b/wine_pizza_cosmos/app.js
@@ -472,10 +472,10 @@ function animate(){
 }
 
 Promise.all([
-  fetch('nodes.json').then(r=>r.json()),
-  fetch('links.json').then(r=>r.json()),
-  fetch('bottle_nodes.json').then(r=>r.json()),
-  fetch('bottle_links.json').then(r=>r.json())
+  fetch('./nodes.json').then(r=>r.json()),
+  fetch('./links.json').then(r=>r.json()),
+  fetch('./bottle_nodes.json').then(r=>r.json()),
+  fetch('./bottle_links.json').then(r=>r.json())
 ])
   .then(([baseNodes, baseLinks, bottleNodes, bottleLinks]) => {
     const labelToId = {};

--- a/wine_pizza_cosmos/bottleGraph.js
+++ b/wine_pizza_cosmos/bottleGraph.js
@@ -10,8 +10,8 @@ const svg = d3.select("body")
   .style("background", "#111");
 
 Promise.all([
-  fetch('bottle_nodes.json').then(r => r.json()),
-  fetch('bottle_links.json').then(r => r.json())
+  fetch('./bottle_nodes.json').then(r => r.json()),
+  fetch('./bottle_links.json').then(r => r.json())
 ]).then(([nodes, links]) => {
   init(nodes, links);
 });

--- a/wine_pizza_cosmos/bottle_index.html
+++ b/wine_pizza_cosmos/bottle_index.html
@@ -9,6 +9,6 @@
   </style>
 </head>
 <body>
-<script type="module" src="bottleGraph.js"></script>
+<script type="module" src="./bottleGraph.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure JSON fetches use `./` relative paths
- update module script references to also use `./`

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint`
