### PR TITLE
Add trippy fluid background

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -8,6 +8,7 @@ import {
   projectPointerToPlane,
   TUNED_PHYS
 } from './helpers/dragPhysics.js';
+import { createFluidBackground } from './helpers/fluidBackground.js';
 
 const scene = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(60, window.innerWidth/window.innerHeight, 0.1, 1000);
@@ -16,7 +17,12 @@ camera.position.set(0, 0, 120);
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.setPixelRatio(window.devicePixelRatio || 1);
+renderer.autoClear = false;
 document.body.appendChild(renderer.domElement);
+
+const bgScene = new THREE.Scene();
+const bgCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+const fluidMesh = createFluidBackground(bgScene);
 
 const labelRenderer = new CSS2DRenderer();
 labelRenderer.setSize(window.innerWidth, window.innerHeight);
@@ -560,6 +566,7 @@ const t0=performance.now();
 const clock = new THREE.Clock();
 function animate(){
   requestAnimationFrame(animate);
+  fluidMesh.material.uniforms.u_time.value = clock.getElapsedTime();
   physics();
   updateAnimation();
   updateFly();
@@ -573,6 +580,8 @@ function animate(){
     if(n.glowSprite)n.glowSprite.scale.set(scale,scale,1);
   });
   controls.update();
+  renderer.clear();
+  renderer.render(bgScene,bgCamera);
   renderer.render(scene,camera);
   labelRenderer.render(scene,camera);
 }
@@ -582,5 +591,7 @@ Promise.all([fetch('nodes.json').then(r=>r.json()), fetch('links.json').then(r=>
 
 window.addEventListener('resize',()=>{
   camera.aspect=window.innerWidth/window.innerHeight;
-  camera.updateProjectionMatrix(); renderer.setSize(window.innerWidth,window.innerHeight);
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth,window.innerHeight);
+  labelRenderer.setSize(window.innerWidth,window.innerHeight);
 });

--- a/docs/helpers/fluidBackground.js
+++ b/docs/helpers/fluidBackground.js
@@ -1,0 +1,41 @@
+import * as THREE from "https://unpkg.com/three@0.153.0/build/three.module.js?module";
+
+export function createFluidBackground(scene) {
+  const geometry = new THREE.PlaneGeometry(2, 2);
+  const material = new THREE.ShaderMaterial({
+    uniforms: {
+      u_time: { value: 0 }
+    },
+    vertexShader: `
+      varying vec2 vUv;
+      void main() {
+        vUv = uv;
+        gl_Position = vec4(position, 1.0);
+      }
+    `,
+    fragmentShader: `
+      precision highp float;
+      uniform float u_time;
+      varying vec2 vUv;
+
+      vec2 swirl(vec2 p, float t) {
+        float r = length(p);
+        float a = atan(p.y, p.x) + t * (0.2 + r * 0.5);
+        return vec2(cos(a), sin(a)) * r;
+      }
+
+      void main() {
+        vec2 p = vUv * 2.0 - 1.0;
+        p = swirl(p, u_time * 0.5);
+        vec3 col = 0.5 + 0.5 * cos(u_time + p.xyx + vec3(0.0, 2.0, 4.0));
+        gl_FragColor = vec4(col, 0.25);
+      }
+    `,
+    transparent: true,
+    depthWrite: false
+  });
+  const mesh = new THREE.Mesh(geometry, material);
+  mesh.frustumCulled = false;
+  scene.add(mesh);
+  return mesh;
+}


### PR DESCRIPTION
## Summary
- create a GLSL shader-based fluid background
- render the background behind the cosmos visualization
- keep renderers in sync on resize

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683becfcfaa08328a11e70b5fbfba19e