### PR TITLE
Add Three.js import to dragPhysics helper

### DIFF
--- a/docs/helpers/dragPhysics.js
+++ b/docs/helpers/dragPhysics.js
@@ -1,3 +1,4 @@
+import * as THREE from "https://unpkg.com/three@0.153.0/build/three.module.js?module";
 /* helpers/dragPhysics.js
  * Minimal utilities for node-dragging & tuned spring physics.
  */


### PR DESCRIPTION
## Summary
- include three.js import at the top of the drag physics helper

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683c98f512208328b9b9e1befdb6a544