### PR TITLE
Lower thresholds for link activation

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -229,9 +229,12 @@ const spriteMat=new THREE.SpriteMaterial({map:glowTex,blending:THREE.AdditiveBle
 
 const threshold=2;
 const lineMat=new THREE.LineBasicMaterial({color:0x8844ff,transparent:true,opacity:0.8});
-const LINK_ACTIVATION_THRESHOLD = 0.8;
-const LINK_BASE_RADIUS = 40;
-const LINK_REMOVAL_FACTOR = 1.5;
+// Lower the threshold so more bonds exist from the start
+const LINK_ACTIVATION_THRESHOLD = 0.6;
+// Allow links to activate from farther away
+const LINK_BASE_RADIUS = 60;
+// Let links persist even if nodes drift slightly apart
+const LINK_REMOVAL_FACTOR = 2.0;
 
 function activateLink(l) {
   if (l.active) return;

--- a/docs/helpers/dragPhysics.js
+++ b/docs/helpers/dragPhysics.js
@@ -24,6 +24,7 @@ export function projectPointerToPlane(event, renderer, camera, plane) {
 export const TUNED_PHYS = {
   linkK:        0.12,  // stiffer springs
   linkLen:      35,    // shorter resting distance
-  repulsionK:   25,    // weaker repulsion so clusters come closer
+  // Reduce repulsion so nodes cluster and links can activate
+  repulsionK:   15,
   centerPull:   0.05   // gentle centering
 };

--- a/wine_pizza_cosmos/app.js
+++ b/wine_pizza_cosmos/app.js
@@ -204,9 +204,9 @@ const spriteMat=new THREE.SpriteMaterial({map:glowTex,blending:THREE.AdditiveBle
 
 const threshold=2;
 const lineMat=new THREE.LineBasicMaterial({color:0x8844ff,transparent:true,opacity:0.8});
-const LINK_ACTIVATION_THRESHOLD = 0.8;
-const LINK_BASE_RADIUS = 40;
-const LINK_REMOVAL_FACTOR = 1.5;
+const LINK_ACTIVATION_THRESHOLD = 0.6;
+const LINK_BASE_RADIUS = 60;
+const LINK_REMOVAL_FACTOR = 2.0;
 
 function activateLink(l) {
   if (l.active) return;


### PR DESCRIPTION
## Summary
- reduce repulsion to let nodes gather
- relax link activation threshold and radius
- extend the link removal distance

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683c9aadfbf88328b43e8217b6ed1498